### PR TITLE
Convert Spawn Configs from enums into sliders

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -1,4 +1,12 @@
 [en enc eng eni ena enz default]
+
+
+// Menu Option Values
+MENU_ENABLED    = "Enabled";
+MENU_DISABLED   = "Disabled";
+MENU_REPLACEALL = "Replace All";
+MENU_WITHALL    = "With All";
+
 // Weapon Tags.
 TAG_ALTIS        = "over-and-under shotgun";
 PICKUP_ALTIS     = "You got the Altis!";

--- a/MENUDEF
+++ b/MENUDEF
@@ -11,12 +11,12 @@ OptionMenu OverUnderShotgun
    	StaticText ""
 	StaticText "Shotguns", 1
     StaticText  "Control the replacement-rate of ssgs.                 ", "white"
-	Option "Replacement Rate: ", "ous_weapon_spawn_bias", "SpawnBias"
+	ScaleSlider "Replacement Rate: ", "ous_weapon_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "Reset spawn options", "resetcvar ous_weapon_spawn_bias"
 	StaticText ""
 	StaticText "Slugs", 1
     StaticText  "Control the chance of alternate ammo spawns (slugs).  ", "white"
-	Option "Slug Spawn Rate: ", "ous_slug_chance_bias", "SpawnBias"
+	ScaleSlider "Slug Spawn Rate: ", "ous_slug_chance_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "Reset slug spawn options", "resetcvar ous_slug_chance_bias"
  	StaticText ""
  	StaticText ""
@@ -32,26 +32,6 @@ OptionMenu OverUnderShotgun
 	SafeCommand "Reset spawn options    ", "ous_reset_cvars"
 	SafeCommand "Reset user  options    ", "ous_reset_user"
 }
-
-
-
-OptionValue "SpawnBias"
-{
-	-1,    "Disabled"
-	 0,    "Replace All"
-	 2,    "1 in 3"
-	 4,    "1 in 5"
-	 9,    "1 in 10"
-	 14,   "1 in 15"
-	 19,   "1 in 20"
-	 24,   "1 in 25"
-	 49,   "1 in 50"
-	 99,   "1 in 100"
-	 149,  "1 in 150"
-	 199,  "1 in 200"
-}
-
-
 
 AddOptionMenu "HDAddonMenu"
 {


### PR DESCRIPTION
This was a suggestion made by prettyFist a while back that I never got around to making a PR for, it converts the enumerated options into ScaleSliders to allow for much more range of spawn options, while keeping the "Replace All" and "Disabled" values for 0 and -1 respectively.